### PR TITLE
Route submit job through GitHub environments

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,7 @@ jobs:
 
   submit:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.ENVIRONMENT || 'staging' }}
     strategy:
       matrix:
         design: ['mcu_soc', 'minimal']


### PR DESCRIPTION
## Summary
- Adds `environment:` to the `submit` job, using `inputs.ENVIRONMENT` (defaulting to `staging`)
- Environment-level `CHIPFLOW_API_ORIGIN` and `CHIPFLOW_API_KEY` have been configured for both `staging` and `production` environments
- Staging submits to `build.staging.chipflow.com`, production to `build.chipflow.com`
- Non-workflow_dispatch triggers (push, PR, merge_group, repository_dispatch) default to staging

## Test plan
- [ ] Merge and trigger `workflow_dispatch` with `ENVIRONMENT=staging` - verify builds submit to staging API
- [ ] Trigger `workflow_dispatch` with `ENVIRONMENT=production` - verify builds submit to production API
- [ ] Verify push to `main` defaults to staging